### PR TITLE
fix: types path and remove unpkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
   "author": "Justin Poehnelt",
   "main": "dist/index.cjs.js",
   "browser": "dist/index.umd.js",
-  "unpkg": "dist/index.min.js",
   "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
close #152 Doesn't really make sense to use this with unpkg, so removing for now. Possible regression in #142.