### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Wrap React components with this libary to load the Google Maps JavaScript API.
+Wrap React components with this library to load the Google Maps JavaScript API.
 
 ```jsx
 import { Wrapper } from "@googlemaps/react-wrapper";


### PR DESCRIPTION
Fixes the spelling error for "library", note that this spelling error is also present in the "About" section for the project.